### PR TITLE
Add kernel to image with PREEMPT_RT patch applied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ addons:
             - shellcheck
 
 script:
-    - shellcheck script/buildscript
+    - shellcheck script/buildscript{,-kernel}

--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+WORKDIR /root
+RUN apt-get update && apt-get --assume-yes install bc build-essential curl libncurses5-dev unzip
+RUN curl -sL 'https://github.com/raspberrypi/linux/archive/rpi-4.4.y.tar.gz' | tar xz
+RUN curl -sL 'https://github.com/raspberrypi/tools/archive/master.tar.gz' | tar xz
+ENV PATH $PATH:/root/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin
+ENV KERNEL kernel7
+WORKDIR /root/linux-rpi-4.4.y

--- a/script/buildscript
+++ b/script/buildscript
@@ -63,7 +63,8 @@ update_linux() {
     execute_in_container apt-get -y clean
     execute_in_container apt-get -y autoremove
 
-    cp -r "$dir"/files/* .
+    cp -r "$dir"/files/etc/* etc/
+    cp -r "$dir"/files/lib/* lib/
 
     printf '%s\n' "$hostname" > etc/hostname
     {
@@ -73,6 +74,7 @@ update_linux() {
 }
 
 update_bootp() {
+    cp -r "$dir"/files/boot/* .
     truncate -s0 config.txt
     {
         printf '%s\n' 'dtparam=spi=on'

--- a/script/buildscript
+++ b/script/buildscript
@@ -22,6 +22,14 @@ download_raspbian_jessie_lite() {
     mv 2016-03-18-raspbian-jessie-lite.img "$destination_image_name"
 }
 
+build_kernel_image() {
+    local -r tag=$(basename "$(mktemp --dry-run)" | awk '{print tolower($0)}')
+
+    docker build --tag "$tag" "$dir"
+    docker run --rm -it -v "$dir":/opt "$tag" /opt/{buildscript-kernel,files}
+    docker rmi "$tag"
+}
+
 execute_in_partition_context() {
     local image_name="$1"
     local partition_offset="$2"
@@ -76,6 +84,7 @@ build_custom_image() {
     local -r hostname=${IMAGE_HOSTNAME:-raspberrypi}
 
     download_raspbian_jessie_lite "raspbian-$hostname.img"
+    build_kernel_image
     linux_offset=$(fdisk -l "raspbian-$hostname.img" | awk -f "$dir"/fdisk-offsets.awk | awk '/Linux/ { print $2 }')
     bootp_offset=$(fdisk -l "raspbian-$hostname.img" | awk -f "$dir"/fdisk-offsets.awk | awk '/FAT32/ { print $2 }')
     execute_in_partition_context "raspbian-$hostname.img" "$linux_offset" 'ext4' update_linux

--- a/script/buildscript
+++ b/script/buildscript
@@ -65,6 +65,7 @@ update_linux() {
 
     cp -r "$dir"/files/etc/* etc/
     cp -r "$dir"/files/lib/* lib/
+    find lib/modules/ -type l -delete
 
     printf '%s\n' "$hostname" > etc/hostname
     {

--- a/script/buildscript-kernel
+++ b/script/buildscript-kernel
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+readonly KERNEL_OUTPUT_DIRECTORY=$1
+
+build_kernel() {
+    curl -s 'https://www.kernel.org/pub/linux/kernel/projects/rt/4.4/patch-4.4.25-rt35.patch.gz' \
+        | gunzip \
+        | patch -p1
+
+    make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
+    make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- menuconfig
+    time make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- -j $(( $(nproc) * 3 / 2 )) zImage modules dtbs
+}
+
+output_image() {
+    mkdir -p "$KERNEL_OUTPUT_DIRECTORY"/{boot,lib}
+    make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH="$KERNEL_OUTPUT_DIRECTORY" modules_install
+    scripts/mkknlimg arch/arm/boot/zImage "$KERNEL_OUTPUT_DIRECTORY/boot/$KERNEL.img"
+    cp -r arch/arm/boot/dts/*.dtb "$KERNEL_OUTPUT_DIRECTORY/boot/"
+    cp -r arch/arm/boot/dts/overlays "$KERNEL_OUTPUT_DIRECTORY/boot/"
+}
+
+build_kernel
+output_image


### PR DESCRIPTION
This PR adds a build script for compiling the Linux kernel from the Raspberry Pi folks' source with the `PREEMPT_RT` patch applied.
