### PR TITLE
Add service for poweroff and restart via GPIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ addons:
             - shellcheck
 
 script:
-    - shellcheck script/buildscript
+    - (
+        for file in $(find script -type f -exec awk -f script/has-shebang.awk {} +);
+        do
+            ( set -x; shellcheck "${file}" );
+        done
+      )

--- a/script/buildscript
+++ b/script/buildscript
@@ -71,6 +71,7 @@ update_bootp() {
     truncate -s0 config.txt
     {
         printf '%s\n' 'dtparam=spi=on'
+        printf '%s\n' 'dtoverlay=gpio-poweroff,gpiopin=4'
     } >> config.txt
 }
 

--- a/script/buildscript
+++ b/script/buildscript
@@ -57,6 +57,8 @@ update_linux() {
     execute_in_container systemctl enable ssh
 
     cp -r "$dir"/files/* .
+    execute_in_container systemctl enable gpio-reboot
+    execute_in_container systemctl enable gpio-poweroff
 
     printf '%s\n' "$hostname" > etc/hostname
     {

--- a/script/files/etc/systemd/system/gpio-poweroff.service
+++ b/script/files/etc/systemd/system/gpio-poweroff.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Poweroff via GPIO PIN #23
+
+[Service]
+User=root
+TimeoutStartSec=0
+Restart=on-failure
+ExecStart=/usr/local/bin/gpio-command 23 poweroff
+
+[Install]
+WantedBy=multi-user.target

--- a/script/files/etc/systemd/system/gpio-reboot.service
+++ b/script/files/etc/systemd/system/gpio-reboot.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reboot via GPIO PIN #24
+
+[Service]
+User=root
+TimeoutStartSec=0
+Restart=on-failure
+ExecStart=/usr/local/bin/gpio-command 24 reboot
+
+[Install]
+WantedBy=multi-user.target

--- a/script/files/usr/local/bin/gpio-command
+++ b/script/files/usr/local/bin/gpio-command
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# Takes a BCM pin number and a command to run and executes the
+# command when the GPIO pin first sees a falling edge. This
+# script doesn't handle signals correctly...so that should be
+# fixed probably—blame RPi.GPIO#wait_for_edge for ignoring 'em.
+#
+# $1 - The BCM GPIO pin number.
+# $@ - Commands to be executed.
+#
+# Examples
+#
+#     gpio-command 23 bash -c 'echo Works?'
+#     gpio-command 24 reboot
+#
+# Returns the exit code of the last command executed
+
+PIN="${1}"
+shift
+
+python -c "
+import RPi.GPIO as GPIO
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(${PIN}, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+GPIO.wait_for_edge(${PIN}, GPIO.FALLING)
+GPIO.cleanup()
+"
+
+printf '%s\n' "+ '$*'"
+"$@"

--- a/script/has-shebang.awk
+++ b/script/has-shebang.awk
@@ -1,0 +1,3 @@
+FNR == 1 && /#!\/usr\/bin\/env bash/ {
+	print FILENAME
+}


### PR DESCRIPTION
Closes LakeMaps/boat#16

This PR adds a service to poweroff or reboot the Pi when a particular GPIO pin is driven low (pins `23` and `24`, respectively). The configuration of the GPIO pins—enabling the pull-up resistors—is done via [a device tree overlay](https://www.raspberrypi.org/documentation/configuration/device-tree.md) (see `poweroff-pins.dts` in the diff below).

Refs:

- This is what I could find re: the device overlay config: [Broadcom BCM2835 GPIO controller](https://www.kernel.org/doc/Documentation/devicetree/bindings/pinctrl/brcm,bcm2835-gpio.txt)
    - It seems to confirm that `brcm,function = <0 0>` is GPIO in and `brcm,pull = <2 2>` is pull-up

I have not tested any of this.