### PR TITLE
Add systemd service file for boat control software

### DIFF
--- a/script/buildscript
+++ b/script/buildscript
@@ -52,6 +52,10 @@ update_linux() {
     local -r hostname=${IMAGE_HOSTNAME:-raspberrypi}
     cp /usr/bin/qemu-arm-static ./usr/bin
 
+    execute_in_container apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
+    execute_in_container sh -c "printf '%s\n' 'deb http://repos.azulsystems.com/debian stable main' > /etc/apt/sources.list.d/zulu.list"
+    execute_in_container apt-get -y update
+    execute_in_container apt-get -y install zulu-embedded-8
     execute_in_container apt-get -y purge 'libraspberrypi-doc'
     execute_in_container apt-get -y clean
     execute_in_container apt-get -y autoremove

--- a/script/files/etc/systemd/system/boat.service
+++ b/script/files/etc/systemd/system/boat.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Boat Control Software
+
+[Service]
+User=pi
+TimeoutStartSec=0
+Restart=on-failure
+ExecStart=/opt/boat/bin/boat 192.168.1.101 /dev/ttyACM1 /dev/ttyACM0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a systemd service file for the boat control software.

Tasks:

- [x] Add the JVM to the image (closes #8)
- [x] Add systemd service file for boat control software (closes #9)