### PR TITLE
Update base Raspbian Lite image

### DIFF
--- a/script/buildscript
+++ b/script/buildscript
@@ -7,20 +7,21 @@ set -o pipefail
 
 download_raspbian_jessie_lite() {
     local destination_image_name="$1"
+    local -r base_image_version="2017-04-10"
 
     [[ -f "$destination_image_name" ]] && return 0
 
     wget --no-clobber --quiet --show-progress \
-        'https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2016-11-29/2016-11-25-raspbian-jessie-lite.zip'
-    checksum=$(openssl dgst -SHA1 2016-11-25-raspbian-jessie-lite.zip | awk '{ print $2 }')
-    if [[ $checksum != '6741a30d674d39246302a791f1b7b2b0c50ef9b7' ]]
+        "https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-$base_image_version/$base_image_version-raspbian-jessie-lite.zip"
+    checksum=$(openssl dgst -SHA1 "$base_image_version-raspbian-jessie-lite.zip" | awk '{ print $2 }')
+    if [[ $checksum != 'c24a4c7dd1a5957f303193fee712d0d2c0c6372d' ]]
     then
         printf '%s\n' 'Bad checksum for download' >&2
         return 1
     fi
 
-    unzip 2016-11-25-raspbian-jessie-lite.zip
-    mv 2016-11-25-raspbian-jessie-lite.img "$destination_image_name"
+    unzip "$base_image_version-raspbian-jessie-lite.zip"
+    mv "$base_image_version-raspbian-jessie-lite.img" "$destination_image_name"
 }
 
 execute_in_partition_context() {


### PR DESCRIPTION
Closes #4

This PR updates the base Rasbian Lite image used to the April 2017 version:

> Version: `April 2017`
> Release date: `2017-04-10`
> Kernel version: `4.4`
> Release notes: `Link`

Changes (from the [release notes](http://downloads.raspberrypi.org/raspbian/release_notes.txt)):

> **2017-04-10:**
>
> * Wolfram Mathematica updated to version 11.0.1
> * Adobe Flash Player updated to version 25.0.0.127
> * Use PARTUUID to support USB boot
>
> **2017-03-02:**
>
> * Updated kernel and firmware (final Pi Zero W support)
> * Wolfram Mathematica updated to version 11
> * NOOBS installs now checks for presence of 'ssh' file on the NOOBS partition.
>
> **2017-02-16:**
>
> * Chromium browser updated to version 56
> * Adobe Flash Player updated to version 24.0.0.221
> * RealVNC Server and Viewer updated to version 6.0.2 (RealVNC Connect)
> * Sonic Pi updated to version 2.11
> * Node-RED updated to version 0.15.3
> * Scratch updated to version 120117
> * Detection of SSH enabled with default password moved into PAM
> * Updated desktop GL driver to support use of fake KMS option
> * Raspberry Pi Configuration and raspi-config allow setting of fixed HDMI resolution
> * raspi-config allows enabling of serial hardware independent of serial terminal
> * Updates to kernel and firmware
> * Various minor bug fixes and usability and appearance tweaks
>
> **2017-01-11:**
>
> * Re-release of the 2016-11-25 image with a FAT32-formatted boot partition