### PR TITLE
Add ability to decrypt encrypted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Build the image
 Run:
 
 ```bash
+IMAGE_BUILD_PASSWORD=password # ???
 IMAGE_HOSTNAME=test1 # ???
-vagrant ssh --command "cd /vagrant && IMAGE_HOSTNAME=$IMAGE_HOSTNAME sudo -E script/buildscript"
+vagrant ssh --command "cd /vagrant && IMAGE_HOSTNAME=$IMAGE_HOSTNAME IMAGE_BUILD_PASSWORD=$IMAGE_BUILD_PASSWORD sudo -E script/buildscript"
 ```
 
 Flash the image
@@ -50,3 +51,14 @@ script/flash-osx "$image" disk2
 ```
 
 Note: the above script spawns a root process (`dd`) to allow it to write to the device. You will need to enter your password when prompted.
+
+Encrypting files
+----------------
+
+Some files used to build the image need to contain passwords or other secure notes—these files should be encrypted before being added to the repository. Use the following command to encrypt `example.txt`:
+
+```bash
+openssl enc -aes-256-cbc -a -salt -in example.txt -out example.txt.enc
+```
+
+By convention, the encrypted file name should be the original file name plus a "`.enc`" suffix.

--- a/script/buildscript
+++ b/script/buildscript
@@ -5,6 +5,13 @@ set -e
 set -u
 set -o pipefail
 
+decrypt_file() {
+    local -r file_name="$1"
+    local -r pass_env="IMAGE_BUILD_PASSWORD"
+
+    openssl enc -d -aes-256-cbc -a -salt -pass "env:${pass_env}" -in "${file_name}" -out "${file_name%%.enc}"
+}
+
 download_raspbian_jessie_lite() {
     local destination_image_name="$1"
     local -r base_image_version="2017-04-10"
@@ -61,6 +68,8 @@ update_linux() {
     execute_in_container apt-get -y clean
     execute_in_container apt-get -y autoremove
 
+    export -f decrypt_file
+    find "$dir"/files -type f -name '*.enc' -exec bash -x -c 'decrypt_file "$0"' {} \;
     cp -r "$dir"/files/* .
     execute_in_container systemctl enable ssh
     execute_in_container systemctl enable gpio-reboot


### PR DESCRIPTION
This PR adds the ability to decrypt files destined for the built image that have been encrypted. 🔒

The process in a nutshell:

1. Add a new file to the appropriate `.gitignore` file
2. Add a new file to the image
3. Encrypt it using `openssl enc -aes-256-cbc -a -salt -in example.txt -out example.txt.enc`
4. Run the build script with the `IMAGE_BUILD_PASSWORD` set to the correct value

The convention here is that every file `x` is encrypted as `x.enc` with the same password. The build script will decrypt all files ending in "`.enc`" (i.e. `*.enc`) to a file without the "`.enc`" suffix.