### PR TITLE
Uninstall packages to create free space on the image

### DIFF
--- a/script/buildscript
+++ b/script/buildscript
@@ -63,10 +63,10 @@ update_linux() {
     execute_in_container apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
     execute_in_container sh -c "printf '%s\n' 'deb http://repos.azulsystems.com/debian stable main' > /etc/apt/sources.list.d/zulu.list"
     execute_in_container apt-get -y update
-    execute_in_container apt-get -y install zulu-embedded-8
-    execute_in_container apt-get -y purge 'libraspberrypi-doc'
+    execute_in_container apt-get -y purge 'build-essential' 'gdb' 'libraspberrypi-doc' 'lua5.1' 'luajit' 'man-db' 'pi-bluetooth' 'wget'
     execute_in_container apt-get -y clean
     execute_in_container apt-get -y autoremove
+    execute_in_container apt-get -y install zulu-embedded-8
 
     export -f decrypt_file
     find "$dir"/files -type f -name '*.enc' -exec bash -x -c 'decrypt_file "$0"' {} \;


### PR DESCRIPTION
Refs #25

This PR rearranges the package installation and uninstallation to have the uninstallation step first so as to create free space on the image for new packages. This isn't a *good* solution. The correct solution to the problem of not having enough space on the image to work with is to not be using an existing image as a base (kinda sorta #18).