### PR TITLE
Keep lua5.1 and luajit packages

### DIFF
--- a/script/buildscript
+++ b/script/buildscript
@@ -63,7 +63,7 @@ update_linux() {
     execute_in_container apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
     execute_in_container sh -c "printf '%s\n' 'deb http://repos.azulsystems.com/debian stable main' > /etc/apt/sources.list.d/zulu.list"
     execute_in_container apt-get -y update
-    execute_in_container apt-get -y purge 'build-essential' 'gdb' 'libraspberrypi-doc' 'lua5.1' 'luajit' 'man-db' 'pi-bluetooth' 'wget'
+    execute_in_container apt-get -y purge 'build-essential' 'gdb' 'libraspberrypi-doc' 'man-db' 'pi-bluetooth' 'wget'
     execute_in_container apt-get -y clean
     execute_in_container apt-get -y autoremove
     execute_in_container apt-get -y install zulu-embedded-8


### PR DESCRIPTION
Uninstalling these autoremoves `raspi-config` which is used on boot to expand the rootfs.