### PR TITLE
Prefer $PWD to calling pwd in a subshell

### DIFF
--- a/script/buildscript
+++ b/script/buildscript
@@ -52,7 +52,7 @@ execute_in_container() {
 
     cp ./etc/$preload ../$preload
     truncate -s0 ./etc/$preload
-    systemd-nspawn --directory "$(pwd)" "$@"
+    systemd-nspawn --directory "$PWD" "$@"
     mv ../$preload ./etc/$preload
 }
 


### PR DESCRIPTION
Closes #26

This PR replaces calling `pwd` in a subshell with `$PWD`