### PR TITLE
Add enable_uart to config

### DIFF
--- a/script/buildscript
+++ b/script/buildscript
@@ -87,6 +87,7 @@ update_bootp() {
     {
         printf '%s\n' 'dtparam=spi=on'
         printf '%s\n' 'dtoverlay=gpio-poweroff,gpiopin=4'
+        printf '%s\n' 'enable_uart=1'
     } >> config.txt
 }
 


### PR DESCRIPTION
This PR enable the mini UART on the Raspberry Pi 3.

> The Linux console can be re-enabled by adding `enable_uart=1` to config.txt. This also fixes the core_freq to 250Mhz (unless force_turbo is set, when it will fixed to 400Mhz), which means that the UART baud rate stays consistent.

— _[The Raspberry Pi UARTs](https://www.raspberrypi.org/documentation/configuration/uart.md)_

See also: _[How do I make serial work on the Raspberry Pi3](https://raspberrypi.stackexchange.com/a/45571)_